### PR TITLE
chore: initial startup and few tweaks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
 
   zookeeper:
     container_name: t1-coding-challenge-zookeeper
-    image: confluentinc/cp-zookeeper:latest
+    image: confluentinc/cp-zookeeper:7.3.2
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
     ports:
@@ -15,15 +15,18 @@ services:
 
   kafka:
     container_name: t1-coding-challenge-kafka
-    image: confluentinc/cp-kafka:latest
+    image: confluentinc/cp-kafka:7.3.2
     depends_on:
       - zookeeper
     ports:
       - "9092:9092"
     environment:
+      KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
 
   kafka-producer:
     container_name: t1-coding-challenge-kafka-producer


### PR DESCRIPTION
During setup the error I encountered ("No such container: t1-coding-challenge-kafka") was been resolved by:
1. Using a specific version of Confluent's Kafka (7.3.2) instead of the latest version
2. Simplifying the Kafka configuration to work with this version
which changes are made in this repo
